### PR TITLE
upgrade @types/styled-components version to fix compile failure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "typescript": "5.0.4"
       },
       "devDependencies": {
-        "@types/styled-components": "^5.1.26"
+        "@types/styled-components": "^5.1.34"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -695,9 +695,9 @@
       "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ=="
     },
     "node_modules/@types/styled-components": {
-      "version": "5.1.26",
-      "resolved": "https://registry.npmjs.org/@types/styled-components/-/styled-components-5.1.26.tgz",
-      "integrity": "sha512-KuKJ9Z6xb93uJiIyxo/+ksS7yLjS1KzG6iv5i78dhVg/X3u5t1H7juRWqVmodIdz6wGVaIApo1u01kmFRdJHVw==",
+      "version": "5.1.34",
+      "resolved": "https://registry.npmjs.org/@types/styled-components/-/styled-components-5.1.34.tgz",
+      "integrity": "sha512-mmiVvwpYklFIv9E8qfxuPyIt/OuyIrn6gMOAMOFUO3WJfSrSE+sGUoa4PiZj77Ut7bKZpaa6o1fBKS/4TOEvnA==",
       "dev": true,
       "dependencies": {
         "@types/hoist-non-react-statics": "*",
@@ -4591,9 +4591,9 @@
       "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ=="
     },
     "@types/styled-components": {
-      "version": "5.1.26",
-      "resolved": "https://registry.npmjs.org/@types/styled-components/-/styled-components-5.1.26.tgz",
-      "integrity": "sha512-KuKJ9Z6xb93uJiIyxo/+ksS7yLjS1KzG6iv5i78dhVg/X3u5t1H7juRWqVmodIdz6wGVaIApo1u01kmFRdJHVw==",
+      "version": "5.1.34",
+      "resolved": "https://registry.npmjs.org/@types/styled-components/-/styled-components-5.1.34.tgz",
+      "integrity": "sha512-mmiVvwpYklFIv9E8qfxuPyIt/OuyIrn6gMOAMOFUO3WJfSrSE+sGUoa4PiZj77Ut7bKZpaa6o1fBKS/4TOEvnA==",
       "dev": true,
       "requires": {
         "@types/hoist-non-react-statics": "*",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
     "typescript": "5.0.4"
   },
   "devDependencies": {
-    "@types/styled-components": "^5.1.26"
+    "@types/styled-components": "^5.1.34"
   }
 }


### PR DESCRIPTION
**Context**:
- command `num run build` fails because of a typescript error
```
./src/app/lib/registry.tsx:18:41
Type error: Property 'clearTag' does not exist on type 'ServerStyleSheet'.

  16 |   useServerInsertedHTML(() => {
  17 |     const styles = styledComponentsStyleSheet.getStyleElement();
> 18 |     styledComponentsStyleSheet.instance.clearTag();
     |                                         ^
  19 |     return <>{styles}</>;
  20 |   });
  21 |
  ```
- the reason is typescript declare package `@types/styled-components` version doesn't match package `styled-components`

**Changes**:
- upgrade package `@types/styled-components` to the latest version